### PR TITLE
Prevent crashes when the Markov blanket is totally empty.

### DIFF
--- a/PyImpetus.py
+++ b/PyImpetus.py
@@ -498,7 +498,7 @@ class PPIMBR(TransformerMixin, BaseEstimator):
         scores = list()
         # If MB is empty, return
         if len(MB) < 1:
-            return list()
+            return list(), list() # Callers expect a pair
         # Generate a list for false positive features
         remove = list()
         # For each feature in MB, check if it is false positive


### PR DESCRIPTION
Hello! In the `fit` method of `PPIMBR` (and not `PPIMBC`), there is sometimes a crash when an empty MB is supplied to `_shrink`.