### PR TITLE
Uncommenting the MIT license line

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
          "Programming Language :: Python :: 3",
          "Programming Language :: Python :: 3.6",
          "Programming Language :: Python :: 3.7",
-         #"License :: OSI Approved :: MIT License",
+         "License :: OSI Approved :: MIT License",
          "Operating System :: OS Independent",
      ]
  )


### PR DESCRIPTION
I noticed that the package was coming up as unknown for licensing metadata, so uncommenting your MIT line in setup.py to match your LICENSE file.